### PR TITLE
Support for no location updates

### DIFF
--- a/android-easylocation/build.gradle
+++ b/android-easylocation/build.gradle
@@ -31,7 +31,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 24
         versionCode 1
-        versionName "1.0.1"
+        versionName "1.0.2"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/android-easylocation/src/main/java/com/akhgupta/easylocation/AppConstants.java
+++ b/android-easylocation/src/main/java/com/akhgupta/easylocation/AppConstants.java
@@ -6,4 +6,6 @@ class AppConstants {
     public static final String ACTION_LOCATION_FETCH_START = "location.fetch.start";
     public static final String ACTION_LOCATION_FETCH_STOP = "location.fetch.stop";
     public static final String INTENT_LOCATION_RECEIVED = "intent.location.received";
+    public static final String INTENT_NO_LOCATION_RECEIVED = "intent.no.location.received";
+
 }

--- a/android-easylocation/src/main/java/com/akhgupta/easylocation/EasyLocationDelegate.java
+++ b/android-easylocation/src/main/java/com/akhgupta/easylocation/EasyLocationDelegate.java
@@ -174,6 +174,8 @@ class EasyLocationDelegate {
     private void registerLocationBroadcastReceiver() {
         IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction(AppConstants.INTENT_LOCATION_RECEIVED);
+        intentFilter.addAction(AppConstants.INTENT_NO_LOCATION_RECEIVED);
+
         LocalBroadcastManager.getInstance(activity).registerReceiver(locationReceiver, intentFilter);
     }
 

--- a/android-easylocation/src/main/java/com/akhgupta/easylocation/EasyLocationListener.java
+++ b/android-easylocation/src/main/java/com/akhgupta/easylocation/EasyLocationListener.java
@@ -6,6 +6,7 @@ interface EasyLocationListener {
     void onLocationPermissionGranted();
     void onLocationPermissionDenied();
     void onLocationReceived(Location location);
+    void noLocationReceived();
     void onLocationProviderEnabled();
     void onLocationProviderDisabled();
 }

--- a/android-easylocation/src/main/java/com/akhgupta/easylocation/LocationBgService.java
+++ b/android-easylocation/src/main/java/com/akhgupta/easylocation/LocationBgService.java
@@ -130,6 +130,10 @@ public class LocationBgService extends Service implements GoogleApiClient.Connec
             intent.setAction(AppConstants.INTENT_LOCATION_RECEIVED);
             intent.putExtra(IntentKey.LOCATION,location);
             LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
+        } else {
+            Intent intent = new Intent();
+            intent.setAction(AppConstants.INTENT_NO_LOCATION_RECEIVED);
+            LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
         }
         if(mLocationMode == AppConstants.SINGLE_FIX)
             stopLocationService();

--- a/android-easylocation/src/main/java/com/akhgupta/easylocation/LocationBroadcastReceiver.java
+++ b/android-easylocation/src/main/java/com/akhgupta/easylocation/LocationBroadcastReceiver.java
@@ -17,6 +17,8 @@ class LocationBroadcastReceiver extends BroadcastReceiver {
         if (intent.getAction().equals(AppConstants.INTENT_LOCATION_RECEIVED)) {
             Location location = intent.getParcelableExtra(IntentKey.LOCATION);
             easyLocationListener.onLocationReceived(location);
+        } else if (AppConstants.INTENT_NO_LOCATION_RECEIVED.equals(intent.getAction())) {
+            easyLocationListener.noLocationReceived();
         }
     }
 }

--- a/app/src/main/java/com/akhgupta/easylocation/demo/MainActivity.java
+++ b/app/src/main/java/com/akhgupta/easylocation/demo/MainActivity.java
@@ -52,6 +52,11 @@ public class MainActivity extends EasyLocationAppCompatActivity {
     }
 
     @Override
+    public void noLocationReceived() {
+        showToast("No location received");
+    }
+
+    @Override
     public void onLocationProviderEnabled() {
         showToast("Location services are now ON");
     }


### PR DESCRIPTION
When calling requestSingleLocationFix and no location is available then no call is made to onLocationReceived. I've added a new method called noLocationReceived that a user can implement in order to do something in case there is no location. 